### PR TITLE
Update Memory.jack

### DIFF
--- a/12/Memory.jack
+++ b/12/Memory.jack
@@ -24,7 +24,7 @@ class Memory {
 
     /** Finds an available RAM block of the given size and returns
      *  a reference to its base address. */
-    function int alloc(int size) {
+    function Array alloc(int size) {
     }
 
     /** De-allocates the given object (cast as an array) by making
@@ -32,3 +32,4 @@ class Memory {
     function void deAlloc(Array o) {
     }    
 }
+


### PR DESCRIPTION
The web IDE will throw the following error "OS subroutine Memory.alloc must follow the interface Array alloc(int)" when the return type is an int instead of an Array.

The web-ide expects the return type to be of type "Array" as defined in web-ide/simulator/src/vm/builtins.ts. See lines 205 to 213 of that file.  The snippet is also attached below.

    "Memory.alloc": {
       func: (memory, os) => {
          const [size] = getArgs(memory, 1);
          return os.memory.alloc(size);
       },
        args: ["int"],
        returnType: "Array",
        type: "function",
    },